### PR TITLE
feat: use default icon for txt files

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,6 @@ lazy_static! {
 		m.insert("ts", "");
 		m.insert("tsx", "");
 		m.insert("twig", "");
-		m.insert("txt", "e");
 		m.insert("vim", "");
 		m.insert("vim", "");
 		m.insert("vue", "﵂");


### PR DESCRIPTION
remove special settings for txt files in map, use default setting to
be consistent with vim-devicons.