### PR TITLE
Fix Panic when Name can't be determined and check the filesystem to determine directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_derive",
+ "temp-dir",
  "thiserror",
 ]
 
@@ -846,6 +847,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "temp-dir"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd16aa9ffe15fe021c6ee3766772132c6e98dfa395a167e16864f61a9cfb71d6"
 
 [[package]]
 name = "terminal_size"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ assert_cmd = "2.0.12"
 colored = "2.0"
 criterion = "0.5.1"
 predicates = "3.0.3"
+temp-dir = "0.1.12"
 
 [[bench]]
 name = "benchmark_cli"
@@ -44,9 +45,14 @@ ci = ["github"]
 # The installers to generate for each app
 installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-unknown-linux-musl",
+  "x86_64-pc-windows-msvc",
+]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
 # Where to host releases
 hosting = ["axodotdev", "github"]
-

--- a/src/devicon_lookup.rs
+++ b/src/devicon_lookup.rs
@@ -74,12 +74,14 @@ impl ParsedLine {
             return icon;
         }
 
-        if let Some(icon) = icon::find_exact_name(self.file.name()) {
-            return icon;
-        }
+        if let Some(name) = self.file.name() {
+            if let Some(icon) = icon::find_exact_name(name) {
+                return icon;
+            }
 
-        if self.file.is_dir() {
-            return icon::find_directory(self.file.name()).unwrap_or(Icons::Dir.value());
+            if self.file.is_dir() {
+                return icon::find_directory(name).unwrap_or(Icons::Dir.value());
+            }
         }
 
         if let Some(ext) = self.file.ext() {
@@ -110,10 +112,13 @@ impl ParsedLine {
     }
 
     fn get_name(&self, flag_long: bool, flag_nameshort: bool, flag_align: Option<usize>) -> String {
+        let Some(name) = self.file.name() else {
+            return "".to_string();
+        };
         let mut name = if flag_nameshort {
-            File::short_path_part(self.file.name(), true)
+            File::short_path_part(name, true)
         } else {
-            self.file.name().to_owned()
+            name.to_owned()
         };
 
         if self.file.is_dir() {

--- a/src/devicon_lookup.rs
+++ b/src/devicon_lookup.rs
@@ -113,7 +113,7 @@ impl ParsedLine {
 
     fn get_name(&self, flag_long: bool, flag_nameshort: bool, flag_align: Option<usize>) -> String {
         let Some(name) = self.file.name() else {
-            return "".to_string();
+            return self.original.clone();
         };
         let mut name = if flag_nameshort {
             File::short_path_part(name, true)

--- a/src/file.rs
+++ b/src/file.rs
@@ -14,11 +14,12 @@ pub const DOTS: &str = "…";
 impl File {
     pub fn new(full_path: &str) -> File {
         let original = full_path.to_string();
+        let path = PathBuf::from(full_path);
 
         File {
             original,
-            path: PathBuf::from(full_path),
-            is_dir: full_path.ends_with(std::path::MAIN_SEPARATOR),
+            is_dir: path.is_dir(),
+            path,
         }
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -130,12 +130,6 @@ impl File {
     }
 
     pub(crate) fn name(&self) -> Option<&str> {
-        // `file_name()` here _might_ not return something if the String is only `..`
-        // but we are choosing to ignore that error here and unwrap. We will panic on `..` input
-        // I believe this would have also panicked on the previous impl because the regex would't have matched
-
-        // The second unwrap is because `PathBuf` works on `OsString` which is not guaranteed to be valid unicode
-        // This library only works on valid unicode, so we unwrap here to panic if it's not valid unicode
         self.path.file_name()?.to_str()
     }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -113,20 +113,27 @@ impl File {
     }
 
     pub fn name_is_one_of(&self, choices: &[&str]) -> bool {
-        choices.contains(&self.name())
-    }
-    pub fn name_matches_set(&self, set: &RegexSet) -> bool {
-        set.is_match(self.name())
+        let Some(name) = self.name() else {
+            return false;
+        };
+        choices.contains(&name)
     }
 
-    pub(crate) fn name(&self) -> &str {
+    pub fn name_matches_set(&self, set: &RegexSet) -> bool {
+        let Some(name) = self.name() else {
+            return false;
+        };
+        set.is_match(name)
+    }
+
+    pub(crate) fn name(&self) -> Option<&str> {
         // `file_name()` here _might_ not return something if the String is only `..`
         // but we are choosing to ignore that error here and unwrap. We will panic on `..` input
         // I believe this would have also panicked on the previous impl because the regex would't have matched
 
         // The second unwrap is because `PathBuf` works on `OsString` which is not guaranteed to be valid unicode
         // This library only works on valid unicode, so we unwrap here to panic if it's not valid unicode
-        self.path.file_name().unwrap().to_str().unwrap()
+        self.path.file_name()?.to_str()
     }
 
     pub(crate) fn is_dir(&self) -> bool {

--- a/src/file.rs
+++ b/src/file.rs
@@ -16,9 +16,11 @@ impl File {
         let original = full_path.to_string();
         let path = PathBuf::from(full_path);
 
+        let is_dir = full_path.ends_with(std::path::MAIN_SEPARATOR) || path.is_dir();
+
         File {
             original,
-            is_dir: path.is_dir(),
+            is_dir,
             path,
         }
     }

--- a/src/file_ext.rs
+++ b/src/file_ext.rs
@@ -67,7 +67,10 @@ impl FileExtensions {
     /// in directories full of source code.
     #[allow(clippy::case_sensitive_file_extension_comparisons)]
     pub fn is_immediate(file: &File) -> bool {
-        file.name().ends_with(".ninja")
+        let Some(name) = file.name() else {
+            return false;
+        };
+        name.ends_with(".ninja")
             || file.name_is_one_of(&[
                 "Makefile",
                 "Cargo.toml",
@@ -196,8 +199,11 @@ impl FileExtensions {
     }
 
     pub fn is_temp(file: &File) -> bool {
-        file.name().ends_with('~')
-            || (file.name().starts_with('#') && file.name().ends_with('#'))
+        let Some(name) = file.name() else {
+            return false;
+        };
+        name.ends_with('~')
+            || (name.starts_with('#') && name.ends_with('#'))
             || file.extension_is_one_of(&["tmp", "swp", "swo", "swn", "bak", "bkp", "bk"])
             || file.extension_is_one_of(&["tmp", "swp", "swo", "swn", "bak", "bkp", "bk"])
     }

--- a/tests/directory.rs
+++ b/tests/directory.rs
@@ -1,0 +1,34 @@
+extern crate assert_cmd;
+
+#[cfg(test)]
+mod integration {
+    use std::fs::create_dir;
+
+    use assert_cmd::Command;
+    use temp_dir::TempDir;
+
+    #[test]
+    fn local_dir_test() {
+        let d = TempDir::new().unwrap();
+        create_dir(d.path().join("test_dir")).unwrap();
+
+        let mut cmd = Command::cargo_bin("devicon-lookup").unwrap();
+        cmd.current_dir(d.path())
+            .write_stdin("test_dir\ntest_dir/".to_string())
+            .assert()
+            .stdout(" test_dir/\n test_dir/\n");
+    }
+
+    #[test]
+    fn absolute_dir_test() {
+        let d = TempDir::new().unwrap();
+        let test_dir = d.path().join("test_dir");
+        create_dir(&test_dir).unwrap();
+
+        let mut cmd = Command::cargo_bin("devicon-lookup").unwrap();
+        cmd.current_dir(d.path())
+            .write_stdin(test_dir.to_str().unwrap().to_string())
+            .assert()
+            .stdout(format!(" {}/\n", test_dir.to_str().unwrap()));
+    }
+}


### PR DESCRIPTION
This fixes some bugs reported by @petobens, thanks so much for the reports!

The first is a panic when the last bit of the path as `..`, because it used `Path::file_name` and paniced on `..`, which is documented to return `None`.
https://doc.rust-lang.org/std/path/struct.Path.html#method.file_name
Now we return a `None` as well, and when we need to render the filename we use the input string instead so we should see `..` un-modified in that case

The second fix is to better identify directories. Now instead of just checking for a trailing slash, we ask the file system as a fallback. This supports both local and absolute paths