### PR TITLE
don't duplicate text after prefix when --color is used along --prefix

### DIFF
--- a/src/devicon_lookup.rs
+++ b/src/devicon_lookup.rs
@@ -196,7 +196,7 @@ impl ParsedLine {
             format!("{} {}", icon, path_name)
         };
 
-        if args.flag_substitute || args.flag_prefix.is_some() {
+        if args.flag_substitute || (args.flag_prefix.is_some() && !args.flag_color) {
             s = self.original.replace(self.file.full_path(), &s);
         }
 

--- a/tests/strip_ansi.rs
+++ b/tests/strip_ansi.rs
@@ -27,6 +27,19 @@ mod integration {
     }
 
     #[test]
+    fn calling_devicon_lookup_with_strip_color_single_file_and_prefix() {
+        colored::control::set_override(true);
+
+        let mut cmd = Command::cargo_bin("devicon-lookup").unwrap();
+        cmd.arg("--color")
+            .arg("--prefix")
+            .arg(":");
+        cmd.write_stdin("test.rs: someline of the file".blue().to_string())
+            .assert()
+            .stdout(" \x1b[34mtest.rs: someline of the file\x1B[0m\n");
+    }
+
+    #[test]
     fn calling_devicon_lookup_with_strip_color_multi_file() {
         colored::control::set_override(true);
 


### PR DESCRIPTION
when using ```--prefix``` along ```--color``` as done in https://github.com/coreyja/fzf.devicon.vim the text comming after the prefix is duplicated

it can be reproduced by
```console
$ rg --column --line-number --no-heading --color=always --smart-case -- Extends vendor/smarty/ | devicon-lookup --color --prefix :
 vendor/smarty/smarty/demo/plugins/resource.extendsall.php:4:4: * Extends All Resource:4:4: * Extends All Resource
 vendor/smarty/smarty/demo/plugins/resource.extendsall.php:11:23:class Smarty_Resource_Extendsall extends Smarty_Internal_Resource_Extends:11:23:class Smarty_Resource_Extendsall extends Smarty_Internal_Resource_Extends
```

while the expected result should be
```console
 vendor/smarty/smarty/demo/plugins/resource.extendsall.php:4:4: * Extends All Resource
 vendor/smarty/smarty/demo/plugins/resource.extendsall.php:11:23:class Smarty_Resource_Extendsall extends Smarty_Internal_Resource_Extends
```

I've added a test and a simple test to fix the problem.