### PR TITLE
support of [K escape code from ag result

### DIFF
--- a/src/devicon_lookup/parsers/color.rs
+++ b/src/devicon_lookup/parsers/color.rs
@@ -2,7 +2,7 @@ use crate::ParserResult;
 use regex::Regex;
 
 lazy_static! {
-    static ref ANSI_COLOR_REGEX: Regex = Regex::new(r"\x1b\[[0-9;]*m").unwrap();
+    static ref ANSI_COLOR_REGEX: Regex = Regex::new(r"\x1b\[([0-9;]*m|K)").unwrap();
 }
 
 pub fn strip_color(input: String) -> ParserResult {

--- a/tests/strip_ansi.rs
+++ b/tests/strip_ansi.rs
@@ -36,4 +36,15 @@ mod integration {
             .assert()
             .stdout(" \x1b[34mtest.rs\x1B[0m\n \x1b[31mtest.rb\x1b[0m\n");
     }
+
+    #[test]
+    fn calling_devicon_lookup_with_strip_color_ag_result() {
+        colored::control::set_override(true);
+
+        let mut cmd = Command::cargo_bin("devicon-lookup").unwrap();
+        cmd.arg("--color");
+        cmd.write_stdin("\x1b[34mtest.rs\x1B[0m\x1b[K".to_string())
+            .assert()
+            .stdout(" \x1b[34mtest.rs\x1B[0m\x1b[K\n");
+    }
 }


### PR DESCRIPTION
in ```ag``` results, the formating include ```ESC[K``` (erase from cursor to end of line) beside the color/graphic escape sequences ```ESC[1;34;{...}m```

that give
```
ESC[1;32mpath/file.phpESC[0mESC[K:ESC[1;33m1234ESC[0mESC[K:30:    some line with a ESC[30;43mmatchESC[0mESC[K in the file
```

as only color/graphic escape sequences a strip with ```--color``` the resulting filename still contain ```ESC[K``` and the filetype not recognised: ```path/file.phpESC[K```
